### PR TITLE
1.4.0-alpha.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@ package-lock.json
 image.jpg
 .env
 external.js
-
+tmp
 .yarn
 .pnp*

--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,4 @@ image.jpg
 releaseit
 .pnp*
 .github
+tmp

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@
 #### I. `getimage` notifications (1.4.0-alpha.1)
 1. Change the default notification level from `info` to `warn`.
 2. Remove compatibility code for environment variable type switches. **If there is an environment variable type switch, it needs to be moved to `external.js` or it will not load on `v1.4.0` and later.**
+#### II. Harmonized management of ad hoc documents (1.4.0-alpha.2)
+Move temporary files to the `/tmp` directory: this directory is automatically cleared and reset after a program restart. The default folder name can be changed via environment variables.Also cache `external.js` synchronously to `/tmp` before subsequent mounts.**Developers need to manually clean up `/image.jpg` created by previous versions (optional)**
 
 ### 1.3.2
 1. Allow custom real IP addresses to be passed into the header.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is the Develop version to preview the `v1.4.0` version of the update. The update is detailed at https://disk.hestudio.net/#s/92fJgs8w
 
-You can listen for version updates on the Develop branch via `https://raw.githubusercontent.com/hestudio-community/bing-wallpaper-get/main/package.json`.
+You can listen for version updates on the Develop branch via `https://registry.npmjs.com/hestudio-bingwallpaper-get/alpha`.
 
 ### Demo and detailed documentation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is the Develop version to preview the `v1.4.0` version of the update. The update is detailed at https://disk.hestudio.net/#s/92fJgs8w
 
-You can listen for version updates on the Develop branch via `https://registry.npmjs.com/hestudio-bingwallpaper-get/alpha`.
+You can listen for version updates on the Develop branch via `https://cdn.jsdelivr.net/npm/hestudio-bingwallpaper-get@alpha/package.json`.
 
 ### Demo and detailed documentation
 

--- a/get.js
+++ b/get.js
@@ -1,6 +1,6 @@
 require('dotenv').config()
 
-const VERSION = '1.4.0-alpha.1'
+const VERSION = '1.4.0-alpha.2'
 
 const express = require('express')
 const schedule = require('node-schedule')
@@ -11,6 +11,10 @@ const app = express()
 const dayjs = require('dayjs')
 
 const hbwgConfig = {}
+
+if (!fs.existsSync('./tmp/')) {
+  fs.mkdirSync('./tmp')
+}
 
 if (process.env.hbwg_port) {
   hbwgConfig.port = Number(process.env.hbwg_port)
@@ -121,7 +125,7 @@ if (hbwgConfig.getupdate !== false) {
  */
 const download = (bingsrc) => {
   const url = hbwgConfig.host + bingsrc.images[0].url
-  exec(String('wget -O image.jpg ' + url))
+  exec(String('wget -O tmp/image.jpg ' + url))
   hbwgConfig.copyright = String(bingsrc.images[0].copyright)
   hbwgConfig.copyrightlink = String(bingsrc.images[0].copyrightlink)
   hbwgConfig.title = String(bingsrc.images[0].title)
@@ -257,7 +261,7 @@ app.get('/getimage', (req, res) => {
     global.ip = ip
   }
   const ip = global.ip
-  res.sendFile(path.join(process.cwd(), 'image.jpg'))
+  res.sendFile(path.join(process.cwd(), 'tmp/image.jpg'))
   getback(ip, '/getimage')
 })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hestudio-bingwallpaper-get",
-  "version": "1.4.0-alpha.1",
+  "version": "1.4.0-alpha.2",
   "description": "A Bing wallpaper API interface that can directly image output images.",
   "main": "get.js",
   "scripts": {


### PR DESCRIPTION
#### II. Harmonized management of ad hoc documents (1.4.0-alpha.2)
Move temporary files to the `/tmp` directory: this directory is automatically cleared and reset after a program restart. The default folder name can be changed via environment variables.Also cache `external.js` synchronously to `/tmp` before subsequent mounts.**Developers need to manually clean up `/image.jpg` created by previous versions (optional)**