### PR TITLE
1.4.0-alpha.6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,9 @@
 1. Allow modification of the cache directory via environment variables.
 2. Provides `warn` level notifications on the console when debug mode is on.
 3. Fix bugs in `getupdate`.
+#### 1.4.0-alpha.6
+1. Fixed the problem that `external.js` could not be loaded normally in npm and docker running modes.
+2. Update Debug Mode
 
 ### 1.3.2
 1. Allow custom real IP addresses to be passed into the header.

--- a/get.js
+++ b/get.js
@@ -1,6 +1,6 @@
 require('dotenv').config()
 
-const VERSION = '1.4.0-alpha.5'
+const VERSION = '1.4.0-alpha.6'
 
 const express = require('express')
 const schedule = require('node-schedule')
@@ -136,11 +136,15 @@ module.exports = {
 
 logback(`heStudio BingWallpaper Get version: ${VERSION}`)
 if (process.env.hbwg_external) {
-  ChildProcess.exec(`uglifyjs ${process.env.hbwg_external} -m -o ${hbwgConfig.tempDir}external.js`)
+  ChildProcess.execSync(`uglifyjs ${process.env.hbwg_external} -m -o ${hbwgConfig.tempDir}external.js`, {
+    cwd: __dirname
+  })
   hbwgConfig.external = require(`${hbwgConfig.tempDir}external.js`)
   logback('An external file has been imported.')
 } else if (fs.existsSync('./external.js')) {
-  ChildProcess.execSync(`uglifyjs ${process.cwd()}/external.js -m -o ${hbwgConfig.tempDir}external.js`)
+  ChildProcess.execSync(`uglifyjs ${process.cwd()}/external.js -m -o ${hbwgConfig.tempDir}external.js`, {
+    cwd: __dirname
+  })
   hbwgConfig.external = require(`${hbwgConfig.tempDir}external.js`)
   logback('An external file has been imported.')
 }
@@ -324,7 +328,7 @@ if (hbwgConfig.apiconfig.debug) {
 </head>
 
 <body>
-  <h1>Configurations</h1>
+  <h1>Debug Information</h1>
   <div>
     <div>
       <h3>API URL Configurations</h3>
@@ -357,6 +361,22 @@ if (hbwgConfig.apiconfig.debug) {
         <p>Update PackageUrl: ${hbwgConfig.packageurl}</p>
         <p>Request header for getting IP: ${hbwgConfig.header}</p>
         <p>Temp Dir: ${hbwgConfig.tempDir}</p>
+      </div>
+    </div>
+    <div>
+      <h3>For Developer</h3>
+      <div>
+        <p>TZ: ${process.env.TZ}</p>
+        <p>Running Dir: ${process.cwd()}</p>
+        <p>Core Dir: ${__dirname}</p>
+        <p>Temp Dir: ${hbwgConfig.tempDir}</p>
+        <p>Node Version: ${process.version}</p>
+        <p>Node Dir: ${process.execPath}
+        <p>Arch Information: ${process.arch}</p>
+        <p>Platform Information: ${process.platform}</p>
+        <p>PID: ${process.pid}</p>
+        <p>Memory Usage: ${JSON.stringify(process.memoryUsage())}</p>
+        <p>Resource Usage ${JSON.stringify(process.resourceUsage())}</p>
       </div>
     </div>
   </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hestudio-bingwallpaper-get",
-  "version": "1.4.0-alpha.5",
+  "version": "1.4.0-alpha.6",
   "description": "A Bing wallpaper API interface that can directly image output images.",
   "main": "get.js",
   "scripts": {
@@ -37,7 +37,6 @@
     "dayjs": "^1.11.10",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
-    "fs": "0.0.1-security",
     "node-schedule": "^2.1.1",
     "uglify-js": "^3.17.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ dependencies:
   express:
     specifier: ^4.18.2
     version: 4.18.2
-  fs:
-    specifier: 0.0.1-security
-    version: 0.0.1-security
   node-schedule:
     specifier: ^2.1.1
     version: 2.1.1
@@ -546,6 +543,15 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /eslint-compat-utils@0.1.2(eslint@8.54.0):
+    resolution: {integrity: sha512-Jia4JDldWnFNIru1Ehx1H5s9/yxiRHY/TimCuUc0jNexew3cF1gI6CYZil1ociakfWO3rRqFjl1mskBblB3RYg==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      eslint: '>=6.0.0'
+    dependencies:
+      eslint: 8.54.0
+    dev: true
+
   /eslint-config-standard@17.1.0(eslint-plugin-import@2.29.0)(eslint-plugin-n@16.3.1)(eslint-plugin-promise@6.1.1)(eslint@8.54.0):
     resolution: {integrity: sha512-IwHwmaBNtDK4zDHQukFDW5u/aTb8+meQWZvNFWkiGmbWjD6bqyuSSBxxXKkCftCUzc1zwCH2m/baCNDLGmuO5Q==}
     engines: {node: '>=12.0.0'}
@@ -599,8 +605,8 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-es-x@7.3.0(eslint@8.54.0):
-    resolution: {integrity: sha512-W9zIs+k00I/I13+Bdkl/zG1MEO07G97XjUSQuH117w620SJ6bHtLUmoMvkGA2oYnI/gNdr+G7BONLyYnFaLLEQ==}
+  /eslint-plugin-es-x@7.4.0(eslint@8.54.0):
+    resolution: {integrity: sha512-WJa3RhYzBtl8I37ebY9p76s61UhZyi4KaFOnX2A5r32RPazkXj5yoT6PGnD02dhwzEUj0KwsUdqfKDd/OuvGsw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=8'
@@ -608,6 +614,7 @@ packages:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.54.0)
       '@eslint-community/regexpp': 4.10.0
       eslint: 8.54.0
+      eslint-compat-utils: 0.1.2(eslint@8.54.0)
     dev: true
 
   /eslint-plugin-import@2.29.0(eslint@8.54.0):
@@ -653,7 +660,7 @@ packages:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.54.0)
       builtins: 5.0.1
       eslint: 8.54.0
-      eslint-plugin-es-x: 7.3.0(eslint@8.54.0)
+      eslint-plugin-es-x: 7.4.0(eslint@8.54.0)
       get-tsconfig: 4.7.2
       ignore: 5.3.0
       is-builtin-module: 3.2.1
@@ -889,10 +896,6 @@ packages:
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
-
-  /fs@0.0.1-security:
-    resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
-    dev: false
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}


### PR DESCRIPTION
#### 1.4.0-alpha.6
1. Fixed the problem that `external.js` could not be loaded normally in npm and docker running modes.
2. Update Debug Mode