### PR TITLE
1.4.0-alpha.7

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,8 +18,11 @@
 2. Provides `warn` level notifications on the console when debug mode is on.
 3. Fix bugs in `getupdate`.
 #### 1.4.0-alpha.6
+1. Update Debug Mode
+#### 1.4.0-alpha.7
 1. Fixed the problem that `external.js` could not be loaded normally in npm and docker running modes.
-2. Update Debug Mode
+2. Add a fault tolerance mechanism for online requests.
+3. Update document.
 
 ### 1.3.2
 1. Allow custom real IP addresses to be passed into the header.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is the Develop version to preview the `v1.4.0` version of the update. The update is detailed at https://storage.hestudio.net/s/LXiX
 
-You can listen for version updates on the Develop branch via `https://cdn.jsdelivr.net/npm/hestudio-bingwallpaper-get@alpha/package.json`.
+You can listen for version updates on the Develop branch via `https://unpkg.com/hestudio-bingwallpaper-get@alpha/package.json`.
 
 ### Demo and detailed documentation
 
@@ -61,7 +61,7 @@ git clone https://github.com/hestudio-community/bing-wallpaper-get.git
 cd bing-wallpaper-get
 npm install --global pnpm
 pnpm install --production
-pnpm server
+pnpm run server
 ```
 
 > We will use `pnpm` as the package manager after version 1.3.2. If you deploy in this way, please switch in time to avoid any impact.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hestudio-bingwallpaper-get",
-  "version": "1.4.0-alpha.6",
+  "version": "1.4.0-alpha.7",
   "description": "A Bing wallpaper API interface that can directly image output images.",
   "main": "get.js",
   "scripts": {


### PR DESCRIPTION
#### 1.4.0-alpha.7
1. Fixed the problem that `external.js` could not be loaded normally in npm and docker running modes.
2. Add a fault tolerance mechanism for online requests.
3. Update document.